### PR TITLE
Adding analytics.ga key to config and template

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -67,8 +67,8 @@ gulp.task('ejs', () => {
   const settings = { ext: '.html' }
   const config = {
     data: {
-      env: process.env.NODE_ENV
-      // analytics: { ga: 1010 }
+      env: process.env.NODE_ENV,
+      analytics: { ga: 'UA-2909836-24' }
     }
   }
   gulp.src(srcPaths.ejs)

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -17,7 +17,7 @@
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-            ga('create', '', 'auto');
+            ga('create', '<%= data.analytics.ga %>', 'auto');
             ga('send', 'pageview');
         </script>
         <% } %>


### PR DESCRIPTION
**CHANGELOG**

* We were not tracking visits on page, because `ga` key was not on config;

**OBS:** the access to Google Analytics Dashboard will be with @frontendbr/adminevents 