### PR TITLE
Localização do BrazilJS OnTheRoad Curitiba

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -91,8 +91,8 @@
     "link": "https://braziljs.org/eventos/otr-curitiba/2019/",
     "price": "Consultar",
     "location": {
-      "city": "Porto Alegre",
-      "state": "RS",
+      "city": "Curitiba",
+      "state": "PR",
       "address": "FESP",
       "locationUrl": "https://goo.gl/maps/Wa6TYKd5amboCejk7"
     },


### PR DESCRIPTION
Cidade e estado estavam errados, como se o evento fosse acontecer em Porto Alegre- RS